### PR TITLE
add script to generate unique steuerids using command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ npm install validate-steuerid
 yarn add validate-steuerid
 ```
 # Usage
+## As a module
 
 You can either validate steuerId or generate a valid steuerId
+
 ```js
 import { isSteuerIdValid, generateSteuerId, generateUniqueSteuerIds } from 'validate-steuerid'
 
@@ -30,6 +32,10 @@ generateSteuerId()
 generateUniqueSteuerIds(2)
 // => array of 2 unique steuer id strings
 ```
+## Shell
+```shell
+yarn generateUniqueSteuerIds 20
+```
 
 # Methods
 ## isSteuerIdValid(steuerId)
@@ -45,7 +51,7 @@ generateUniqueSteuerIds(2)
   - type: `number`
 * ### Returns `Array`:
   - type: `string`
-  
+
 <br>
 
 # References

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "main": "./dist/main.js",
   "scripts": {
     "build": "webpack",
-    "test": "mocha ./test/**/*.js"
+    "test": "mocha ./test/**/*.js",
+    "generateUniqueSteuerIds": "node scripts/generateUniqueSteuerIds.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",

--- a/scripts/generateUniqueSteuerIds.js
+++ b/scripts/generateUniqueSteuerIds.js
@@ -1,0 +1,2 @@
+const main = require("../dist/main");
+console.info(main.generateUniqueSteuerIds(Number(process.argv[2])));

--- a/scripts/generateUniqueSteuerIds.js
+++ b/scripts/generateUniqueSteuerIds.js
@@ -1,2 +1,2 @@
 const main = require("../dist/main");
-console.info(main.generateUniqueSteuerIds(Number(process.argv[2])));
+console.dir(main.generateUniqueSteuerIds(Number(process.argv[2])), {maxArrayLength: null});


### PR DESCRIPTION
This allows generation of steuerids from shell.

Purpose:
Sometimes users use existing steuerids in POA form/wizard and when we want to test it manually, it's easy to run out of valid steuerids as we add multiple users and dependents. This would give us many steuerids to be used in manual tests.

Example:
<img width="544" alt="Screenshot 2022-10-31 at 14 18 03" src="https://user-images.githubusercontent.com/6367201/198996138-c8fd32eb-f2ca-4b75-898c-e19638ddf610.png">
