### PR TITLE
Fix flaws

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-steuerid",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Package to validate German tax ID / steuer ID",
   "keywords": [
     "deutschland",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,19 +36,38 @@ const groupByNumOfOccurrences = (map: Object) => {
   return result;
 }
 
-// has to have either one double digit OR one triple digit, never both.
-const checkDoubleOrTriple = (groupedByOccurrences = {}) => {
-  let num2or3occurrences = 0;
+const checkConstraints = (groupedByOccurrences = {}, length: number) => {
+  // there are always digits which do not repeat
+  if (!('1' in groupedByOccurrences)) {
+    return false;
+  }
+
+  // at least one digit has to repeat two or three times
+  // check not active while generating tax ids (shorter than 10 digits)
+  if (length === 10 && !('2' in groupedByOccurrences) && !('3' in groupedByOccurrences)) {
+    return false;
+  }
+
+  // has to have either double digit OR triple digit, never both
+  if ('2' in groupedByOccurrences && '3' in groupedByOccurrences) {
+    return false;
+  }
+
+  // if a digit repeats two times - only one digit should do that
+  if (groupedByOccurrences['2']?.length > 1) {
+    return false;
+  }
+
+  // if a digit repeats three times - only one digit should do that
+  if (groupedByOccurrences['3']?.length > 1) {
+    return false;
+  }
 
   for (const key in groupedByOccurrences) {
     const occurrence = parseInt(key);
 
-    // if there is more than 1 2or3 occurrences return false
-    if (occurrence >= 2) {
-      num2or3occurrences++;
-    }
-
-    if (num2or3occurrences > 1) {
+    // no digit should repeat more than 3 times
+    if (occurrence > 3) {
       return false;
     }
   }
@@ -97,7 +116,7 @@ export function isOccurrencesValid(digits: number[]) {
     validConsecutive = checkConsecutivePositions(digits);
   }
 
-  return checkDoubleOrTriple(groupedByOccurrences) && validConsecutive;
+  return checkConstraints(groupedByOccurrences, digits.length) && validConsecutive;
 }
 
 export function isSteuerIdValid(steuerId: string): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -6,21 +6,37 @@ const examples = [
   { steuerId: '26954371827', expected: true },
   { steuerId: '86095742719', expected: true },
   { steuerId: '65929970489', expected: true },
+
   { steuerId: '65299970480', expected: false },
-  { steuerId: '26954371820', expected: false }
-]
+  { steuerId: '26954371820', expected: false },
+  { steuerId: '37505648067', expected: false },
+  { steuerId: '11112345678', expected: false },
+  { steuerId: '11111345677', expected: false },
+  { steuerId: '11111145670', expected: false },
+  { steuerId: '11111115672', expected: false },
+  { steuerId: '11111111670', expected: false },
+  { steuerId: '11111111178', expected: false },
+  { steuerId: '11111111119', expected: false },
+
+  // official examples from table 2-1 of https://download.elster.de/download/schnittstellen/Pruefung_der_Steuer_und_Steueridentifikatsnummer.pdf
+  { steuerId: '86095742719', expected: true },
+  { steuerId: '47036892816', expected: true },
+  { steuerId: '65929970489', expected: true },
+  { steuerId: '57549285017', expected: true },
+  { steuerId: '25768131411', expected: true },
+];
 
 describe('isSteuerIdValid function', () => {
   for (const example of examples) {
-    it('validates a steuerId successfully', () => {
+    it('validates a steuerId ' + example.steuerId + ' and returns ' + example.expected, () => {
       assert.strictEqual(isSteuerIdValid(example.steuerId), example.expected)
     })
   }
-  
+
   it('returns false if steuerId does not contain 11 digits', () => {
     assert.strictEqual(isSteuerIdValid('26954371'), false)
   })
-  
+
   it('returns false if steuerId contains non numerical characters', () => {
     assert.strictEqual(isSteuerIdValid('26954371rfe'), false)
   })


### PR DESCRIPTION
Your package has major flaws and returns `true` for invalid tax-ids - for example: `11112345678` or `37505648067`.

Based on chapter 2.2 of the [official documentation](https://download.elster.de/download/schnittstellen/Pruefung_der_Steuer_und_Steueridentifikatsnummer.pdf) only one digit has to repeat either two or three times within the first 10 digits. Your code did not check this constraint.

This PR concentrates on fulfilling the mentioned constraint.